### PR TITLE
Fix link to Bell Labs User's Reference to B

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ Blang is licensed under the MIT License. See `LICENSE` in this repository for fu
 
 ### References
 
-- [Bell Labs User's Reference to B](https://www.bell-labs.com/usr/dmr/www/kbman.pdf) by Ken Thompson (Jan. 7, 1972)
+- [Bell Labs User's Reference to B](https://web.archive.org/web/20240408212027/https://www.bell-labs.com/usr/dmr/www/kbman.pdf) by Ken Thompson (Jan. 7, 1972)
 
 - Wikipedia entry: [B (programming language)](https://en.wikipedia.org/wiki/B_(programming_language))


### PR DESCRIPTION
The PDF is no longer available, it returns 410 error. Found a copy in Archive.org